### PR TITLE
Add DEFAULT_AUTO_FIELD setting because warning about imortcsv.csvData

### DIFF
--- a/tempdjango/settings.py
+++ b/tempdjango/settings.py
@@ -88,6 +88,7 @@ DATABASES = {
     }
 }
 
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 # Password validation
 # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators


### PR DESCRIPTION
In newer django versions ( > 3.2) we need to have a default setting for auto created fields 
In this pull request I add this.